### PR TITLE
fix: change state initialization lifecycle

### DIFF
--- a/mvi-presenter/src/main/java/pl/valueadd/mvi/exception/ViewNotAttachedException.kt
+++ b/mvi-presenter/src/main/java/pl/valueadd/mvi/exception/ViewNotAttachedException.kt
@@ -1,4 +1,4 @@
 package pl.valueadd.mvi.exception
 
-internal class ViewNotAttachedException :
+class ViewNotAttachedException internal constructor() :
     RuntimeException("View was called before that has been attached to presenter")

--- a/mvi-presenter/src/main/java/pl/valueadd/mvi/exception/ViewWasNotDetachedException.kt
+++ b/mvi-presenter/src/main/java/pl/valueadd/mvi/exception/ViewWasNotDetachedException.kt
@@ -1,5 +1,4 @@
 package pl.valueadd.mvi.exception
 
-import java.lang.RuntimeException
-
-internal class ViewWasNotDetachedException : RuntimeException("Detach previous view first.")
+class ViewWasNotDetachedException internal constructor() :
+    RuntimeException("Detach previous view first.")

--- a/mvi-presenter/src/main/java/pl/valueadd/mvi/presenter/IMviPresenter.kt
+++ b/mvi-presenter/src/main/java/pl/valueadd/mvi/presenter/IMviPresenter.kt
@@ -2,6 +2,8 @@ package pl.valueadd.mvi.presenter
 
 interface IMviPresenter<V : IBaseView<*, *>> {
 
+    fun initializeState(view: V)
+
     fun attachView(view: V)
 
     fun detachView()

--- a/mvi-presenter/src/test/java/pl/valueadd/mvi/presenter/BaseMviPresenterTest.kt
+++ b/mvi-presenter/src/test/java/pl/valueadd/mvi/presenter/BaseMviPresenterTest.kt
@@ -8,7 +8,8 @@ import io.mockk.verify
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
-import org.junit.jupiter.api.Assertions
+/* ktlint-disable no-wildcard-imports */
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -47,11 +48,12 @@ class BaseMviPresenterTest {
         val firstView = createMockView(Observable.never())
         val secondView: IBaseView<TestViewState, TestViewIntent> = mockk()
 
+        presenter.initializeState(firstView)
         presenter.attachView(firstView)
 
         // When
         // Then
-        Assertions.assertThrows(ViewWasNotDetachedException::class.java) {
+        assertThrows(ViewWasNotDetachedException::class.java) {
             presenter.attachView(secondView)
         }
     }
@@ -61,6 +63,7 @@ class BaseMviPresenterTest {
         // Given
         val viewIntentsSubject = PublishSubject.create<TestViewIntent>()
         val mockView = createMockView(viewIntentsSubject)
+        presenter.initializeState(mockView)
 
         // When
         presenter.attachView(mockView)
@@ -75,6 +78,7 @@ class BaseMviPresenterTest {
         // Given
         val viewIntentsSubject = PublishSubject.create<TestViewIntent>()
         val mockView = createMockView(viewIntentsSubject)
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
 
         // When
@@ -82,7 +86,7 @@ class BaseMviPresenterTest {
 
         // Then
         verify(exactly = 1) { mockView.provideViewIntents() }
-        assert(viewIntentsSubject.hasObservers() == false)
+        assertFalse(viewIntentsSubject.hasObservers())
     }
 
     @Test
@@ -94,6 +98,7 @@ class BaseMviPresenterTest {
         val mockView = createMockView(Observable.never())
 
         every { mockReducer.reduce(any(), testPresenterPartialState) } returns expectedTestViewState
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
 
         // When
@@ -117,6 +122,7 @@ class BaseMviPresenterTest {
         val reducedViewState = TestViewState(1)
         every { mockMapper.mapViewIntentToPartialState(testViewIntent) } returns testPartialStatePublishSubject
         every { mockReducer.reduce(any(), testPartialState) } returns reducedViewState
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
         viewIntentsSubject.onNext(testViewIntent) // For example user press login button
 
@@ -139,6 +145,7 @@ class BaseMviPresenterTest {
 
         every { mockMapper.mapViewIntentToPartialState(testViewIntent) } returns testPartialStatePublishSubject
         every { mockReducer.reduce(any(), testPartialState) } returns reducedViewState
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
         viewIntentsSubject.onNext(testViewIntent) // For example user press login button
         presenter.detachView() // View of fragment is destroyed by system
@@ -161,6 +168,7 @@ class BaseMviPresenterTest {
         val mockView = createMockView(viewIntentsSubject)
         every { mockMapper.mapViewIntentToPartialState(testViewIntent) } returns testPartialStatePublishSubject
         every { mockReducer.reduce(any(), testPartialState) } returns reducedViewState
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
         viewIntentsSubject.onNext(testViewIntent) // For example user press login button
 
@@ -186,6 +194,7 @@ class BaseMviPresenterTest {
 
         every { mockMapper.mapViewIntentToPartialState(testViewIntent) } returns testPartialStatePublishSubject
         every { mockReducer.reduce(any(), testPartialState) } returns reducedViewState
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
         viewIntentsSubject.onNext(testViewIntent) // For example user press login button
 
@@ -208,6 +217,7 @@ class BaseMviPresenterTest {
 
         every { mockMapper.mapViewIntentToPartialState(testViewIntent) } returns testPartialStatePublishSubject
         every { mockReducer.reduce(any(), testPartialState) } returns reducedViewState
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
         viewIntentsSubject.onNext(testViewIntent) // For example user press login button
 
@@ -215,8 +225,8 @@ class BaseMviPresenterTest {
         presenter.destroy()
 
         // Then
-        assert(testPartialStatePublishSubject.hasObservers() == false)
-        assert(presenterPublishSubject.hasObservers() == false)
+        assertFalse(testPartialStatePublishSubject.hasObservers())
+        assertFalse(presenterPublishSubject.hasObservers())
     }
 
     @Test
@@ -228,6 +238,7 @@ class BaseMviPresenterTest {
         every { mockThrowable.stackTrace } returns emptyArray()
         every { mockThrowable.cause } returns null
         every { mockTestLogger.logError(any()) } returns Unit
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
 
         // When
@@ -246,6 +257,7 @@ class BaseMviPresenterTest {
         every { mockThrowable.stackTrace } returns emptyArray()
         every { mockThrowable.cause } returns null
         every { mockTestLogger.logError(any()) } returns Unit
+        presenter.initializeState(mockView)
         presenter.attachView(mockView)
 
         // When

--- a/mvi/build.gradle
+++ b/mvi/build.gradle
@@ -27,6 +27,7 @@ android {
         unitTests.all {
             useJUnitPlatform()
         }
+        unitTests.returnDefaultValues = true
     }
 
     buildTypes {

--- a/mvi/src/main/java/pl/valueadd/mvi/fragment/delegate/fragment/MviFragmentDelegateImpl.kt
+++ b/mvi/src/main/java/pl/valueadd/mvi/fragment/delegate/fragment/MviFragmentDelegateImpl.kt
@@ -1,6 +1,7 @@
 package pl.valueadd.mvi.fragment.delegate.fragment
 
 import android.os.Bundle
+import androidx.annotation.CallSuper
 import pl.valueadd.mvi.presenter.BaseMviPresenter
 import pl.valueadd.mvi.presenter.IBaseView
 
@@ -14,22 +15,27 @@ open class MviFragmentDelegateImpl<V : IBaseView<*, *>>(
     protected val presenter: BaseMviPresenter<*, *, *, V>
 ) : MviFragmentDelegate {
 
+    @CallSuper
     override fun onCreate(savedInstanceState: Bundle?) {
-        // no-op
+        presenter.initializeState(fragment)
     }
 
+    @CallSuper
     override fun onSaveInstanceState(outState: Bundle) {
         // no-op
     }
 
+    @CallSuper
     override fun onStart() {
         presenter.attachView(fragment)
     }
 
+    @CallSuper
     override fun onStop() {
         presenter.detachView()
     }
 
+    @CallSuper
     override fun onDestroy() {
         presenter.destroy()
     }

--- a/mvi/src/main/java/pl/valueadd/mvi/fragment/delegate/fragment/MviFragmentSaveInstanceStateDelegateImpl.kt
+++ b/mvi/src/main/java/pl/valueadd/mvi/fragment/delegate/fragment/MviFragmentSaveInstanceStateDelegateImpl.kt
@@ -26,11 +26,13 @@ class MviFragmentSaveInstanceStateDelegateImpl<V : IBaseView<VS, *>, VS : IBaseV
         private set
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         this.restoredViewState =
             savedInstanceState?.getParcelable(VIEW_STATE_BUNDLE_KEY)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
         outState.putParcelable(
             VIEW_STATE_BUNDLE_KEY,
             presenter.currentState as Parcelable

--- a/mvi/src/test/java/pl/valueadd/mvi/fragment/base/BaseMviFragmentTest.kt
+++ b/mvi/src/test/java/pl/valueadd/mvi/fragment/base/BaseMviFragmentTest.kt
@@ -1,11 +1,11 @@
 package pl.valueadd.mvi.fragment.base
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+/* ktlint-disable no-wildcard-imports */
+import io.mockk.*
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.parcel.Parcelize
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import pl.valueadd.mvi.IBaseViewState
@@ -25,6 +25,26 @@ class BaseMviFragmentTest {
         mockPresenter = mockk(relaxed = true)
         fragment = TestMviFragment()
         fragment.presenter = mockPresenter
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Should call initialize state on presenter on create`() {
+        // Given
+        val mockActivity = mockk<TestActivity>(relaxed = true) {
+            every { supportDelegate } returns mockk(relaxed = true)
+        }
+        fragment.onAttach(mockActivity)
+
+        // When
+        fragment.onCreate(null)
+
+        // Then
+        verify(exactly = 1) { mockPresenter.initializeState(fragment) }
     }
 
     @Test


### PR DESCRIPTION
Request change for android.

Activity is calling save instance state on child
fragments before the view was attached
when the currentState was uninitialized which
leads to crash.

We are using currentState in onSaveInstanceState to keep
state in android.

Presenter's initializeState gives flexibility to init a state
depending on platform specific requirements.

Also fixed type, expose exceptions classes to give possibility to
handle exceptions from library.